### PR TITLE
automatically requires adapters passed as string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+.tmp/

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,16 @@ exports.register = function(plugin, options, next) {
             Waterline.Collection.extend(model)
         );
     }
+
+    // Require the adapters modules if strings are passed instead of objects
+    var keys =  Object.keys(options.adapters);
+    for (var i = 0; i < keys.length; i++) {
+
+        if (typeof options.adapters[keys[i]] === 'string') {
+            options.adapters[keys[i]] = require(options.adapters[keys[i]]);
+        }
+
+    }
     
     // Now init using the proper config and expose the model to Hapi
     waterline.initialize({

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "devDependencies": {
         "lab": "4.x.x",
         "hapi": "~7.x.x",
+        "sails-disk": "^0.10.5",
         "sails-memory": "^0.10.x"
     },
     "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,9 @@ experiment('Dogwater', function () {
     var dummyAdapters = { foo: {} };
     
     var failureAdapters = 666;
+
+    // Pass adapters as string
+    var stringsAdapters = { foo : 'sails-disk' };
     
     // Setup adapters for testing fixtures.
     var fixtureAdapters = { foo: require('sails-memory') };
@@ -45,6 +48,27 @@ experiment('Dogwater', function () {
         var options = {
             connections: connections,
             adapters: dummyAdapters,
+            models: Path.normalize(__dirname + '/' + modelsFile)
+        };
+
+        var plugin = {
+           plugin: require('..'),
+           options: options
+        };
+        
+        server.pack.register(plugin, function (err) {
+            
+            expect(err).to.not.exist;
+            
+            done();
+        });
+    });
+
+    test('takes its adapters option as a string.', function (done) {
+        
+        var options = {
+            connections: connections,
+            adapters: stringsAdapters,
             models: Path.normalize(__dirname + '/' + modelsFile)
         };
 


### PR DESCRIPTION
I have the following problem:

I wrote a `manifest.json` where I configured dogwater like this:
```
    "dogwater": {
      "connections": {
        "diskDB": {
          "adapter": "disk"
        }
      },
      "adapters": {
        "disk": "sails-disk"
      },
      "models": [{
        "identity": "person",
        "connection": "diskDB",
        "attributes": {
          "name": "string"
        }
      }]
    }
```

This is extremely useful because I can then start my server using [hapijs/rejoice](https://github.com/hapijs/rejoice) without writing javascript code. Only configuring the system through a JSON file. This should be the hapijs approach.

Applying this patch I will be able to pass a string, which will be `required`, or choose to pass a complete object in there.

What do you think about it ?